### PR TITLE
Changes from Pull destination testing

### DIFF
--- a/lib/datasift.js
+++ b/lib/datasift.js
@@ -138,7 +138,19 @@ DataSift.prototype._dispatch = function (route, params, callback) {
 		}
 
 		try {
-			body = JSON.parse(body);
+			if (response.headers['x-datasift-format'] == 'json_new_line') {
+				var lines = body.split("\n");
+				var body = [];
+
+				lines.forEach(function(line) {
+					body.push(JSON.parse(line));
+				});
+
+			}
+			else
+			{
+				body = JSON.parse(body);
+			}
 		} catch (e) {
 			return callback({
 				message: 'Invalid JSON',


### PR DESCRIPTION
Switches between QS / form params as applicable for method type
Temporary fix for 204 status code issue DM-3137
Removed test for content type return from API
Now returns headers from API responses
