### PR TITLE
ETIMEDOUT causes uncaught exception error

### DIFF
--- a/lib/datasift.js
+++ b/lib/datasift.js
@@ -149,7 +149,7 @@ DataSift.prototype._dispatch = function () {
 			if(err.code === "HPE_INVALID_CONSTANT") {
 				return callback();
 			} else {
-				return callback(err, null, response.headers, response.statusCode);
+				return callback(err, null, response ? response.headers : null, response ? response.statusCode : null);
 			}
 		}
 


### PR DESCRIPTION
I hit to timeout error which causes uncaught exception error (error: uncaughtException: Cannot read property 'headers').  The reason was that the error handler try to use response.header variable but response was null.

The problem is in [lib/datasift.js on line 152](https://github.com/datasift/datasift-node/blob/master/lib/datasift.js#L152).

I made this quick fix to avoid uncaught exception error.
